### PR TITLE
Rebalance personal storage

### DIFF
--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -18,7 +18,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	if(STR)
-		STR.max_combined_w_class = 6
+		STR.max_combined_w_class = 12
 		STR.max_w_class = WEIGHT_CLASS_SMALL
 		STR.max_items = heldz_items
 
@@ -42,6 +42,7 @@
 /obj/item/storage/belt/rogue/leather/plaquegold
 	name = "plaque belt"
 	icon_state = "goldplaque"
+	heldz_items = 5
 	sellprice = 50
 	sewrepair = FALSE
 	anvilrepair = /datum/skill/craft/armorsmithing
@@ -59,6 +60,7 @@
 /obj/item/storage/belt/rogue/leather/plaquesilver
 	name = "plaque belt"
 	icon_state = "silverplaque"
+	heldz_items = 4
 	sellprice = 30
 	sewrepair = FALSE
 	anvilrepair = /datum/skill/craft/armorsmithing
@@ -66,6 +68,7 @@
 /obj/item/storage/belt/rogue/leather/steel
 	name = "steel belt"
 	icon_state = "steelplaque"
+	heldz_items = 4
 	sellprice = 30
 	sewrepair = FALSE
 	anvilrepair = /datum/skill/craft/armorsmithing
@@ -218,7 +221,7 @@
 	if(STR)
 		STR.max_combined_w_class = 21
 		STR.max_w_class = WEIGHT_CLASS_NORMAL
-		STR.max_items = 5
+		STR.max_items = 3
 		STR.click_gather = TRUE
 		STR.allow_quick_empty = TRUE
 		STR.allow_dump_out = TRUE

--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -18,7 +18,7 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	if(STR)
-		STR.max_combined_w_class = 12
+		STR.max_combined_w_class = 10
 		STR.max_w_class = WEIGHT_CLASS_SMALL
 		STR.max_items = heldz_items
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Satchel item storage 5 -> 3
All belts can hold more weight, meaning you can store multiple daggers/bottles/etc in one belt
Steel/Silver belt item storage 3 -> 4
Gold belt item storage 3 -> 5
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Provides an upgrade path for small storage items, which are reasonable utility and backup weapons. Satchels are far too good, with 2 of them you're able to carry the same amount of items as a cart. Dumb. Now you should invest in a better belt if you want to carry around more knick knacks.
Or get a backpack.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
