### PR TITLE
Occultist Subclasses

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -58,6 +58,7 @@
 #define COLOR_ASSEMBLY_LBLUE   "#5D99BE"
 #define COLOR_ASSEMBLY_BLUE    "#38559E"
 #define COLOR_ASSEMBLY_PURPLE  "#6F6192"
+#define COLOR_ASSEMBLY_FAKEGOLD "#edce41"
 
 
 //roguetown

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -235,7 +235,7 @@
 /obj/item/clothing/suit/roguetown/armor/plate/scale/fakegold
 	name = "gold scalemail"
 	desc = "Gold scales interwoven intricately to form flexible protection! Wait, this is actually steel."
-	color = COLOR_ASSEMBLY_YELLOW
+	color = COLOR_ASSEMBLY_FAKEGOLD
 
 /obj/item/clothing/suit/roguetown/armor/heartfelt/lord
 	slot_flags = ITEM_SLOT_ARMOR

--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -212,6 +212,7 @@
 	armor_class = ARMOR_CLASS_MEDIUM
 	smelt_bar_num = 2
 
+
 /obj/item/clothing/suit/roguetown/armor/plate/half/elven
 	name = "elven guardian cuirass"
 	desc = "A cuirass made of steel with a thin decorative gold plating. Lightweight and durable."
@@ -230,6 +231,11 @@
 	equip_delay_self = 4 SECONDS
 	armor_class = ARMOR_CLASS_MEDIUM
 	smelt_bar_num = 2
+
+/obj/item/clothing/suit/roguetown/armor/plate/scale/fakegold
+	name = "gold scalemail"
+	desc = "Gold scales interwoven intricately to form flexible protection! Wait, this is actually steel."
+	color = COLOR_ASSEMBLY_YELLOW
 
 /obj/item/clothing/suit/roguetown/armor/heartfelt/lord
 	slot_flags = ITEM_SLOT_ARMOR

--- a/code/modules/clothing/rogueclothes/gloves.dm
+++ b/code/modules/clothing/rogueclothes/gloves.dm
@@ -94,7 +94,7 @@
 /obj/item/clothing/gloves/roguetown/chain/fakegold
 	name = "golden chain gauntlets"
 	desc = "Normal steel chain gauntlets painted yellow to mimic gold."
-	color = COLOR_ASSEMBLY_YELLOW
+	color = COLOR_ASSEMBLY_FAKEGOLD
 
 /obj/item/clothing/gloves/roguetown/chain/iron
 	icon_state = "icgloves"

--- a/code/modules/clothing/rogueclothes/gloves.dm
+++ b/code/modules/clothing/rogueclothes/gloves.dm
@@ -91,6 +91,11 @@
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/steel
 
+/obj/item/clothing/gloves/roguetown/chain/fakegold
+	name = "golden chain gauntlets"
+	desc = "Normal steel chain gauntlets painted yellow to mimic gold."
+	color = COLOR_ASSEMBLY_YELLOW
+
 /obj/item/clothing/gloves/roguetown/chain/iron
 	icon_state = "icgloves"
 	anvilrepair = /datum/skill/craft/armorsmithing

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -690,7 +690,7 @@
 /obj/item/clothing/head/roguetown/helmet/heavy/bucket/fakegold
 	name = "golden bucket helmet"
 	desc = "A helmet which covers the whole of the head. It is made of steel, stained yellow."
-	color = COLOR_ASSEMBLY_YELLOW
+	color = COLOR_ASSEMBLY_FAKEGOLD
 
 /obj/item/clothing/head/roguetown/helmet/heavy/bucket/attackby(obj/item/W, mob/living/user, params)
 	..()

--- a/code/modules/clothing/rogueclothes/hats.dm
+++ b/code/modules/clothing/rogueclothes/hats.dm
@@ -687,6 +687,11 @@
 	smeltresult = /obj/item/ingot/steel
 	smelt_bar_num = 2
 
+/obj/item/clothing/head/roguetown/helmet/heavy/bucket/fakegold
+	name = "golden bucket helmet"
+	desc = "A helmet which covers the whole of the head. It is made of steel, stained yellow."
+	color = COLOR_ASSEMBLY_YELLOW
+
 /obj/item/clothing/head/roguetown/helmet/heavy/bucket/attackby(obj/item/W, mob/living/user, params)
 	..()
 	if(istype(W, /obj/item/natural/cloth) && !detail_tag)
@@ -700,7 +705,7 @@
 		"Madroot Red"="#AD4545",
 		"Marigold Orange"="#E2A844",
 		"Politely, Yuck"="#685542",
-		"Astrata's Yellow"="#FFFD8D",
+		"Lightening Yellow"="#FFFD8D",
 		"Bog Green"="#375B48",
 		"Seafoam Green"="#49938B",
 		"Woad Blue"="#395480",

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -60,10 +60,10 @@
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/steel
 
-/obj/item/clothing/neck/roguetown/chaincoif/fakegold
+/obj/item/clothing/neck/roguetown/chaincoif
 	name = "golden chain coif"
 	desc = "A normal steel coif painted yellow in an attempt to mimic gold."
-	color = COLOR_ASSEMBLY_YELLOW
+	color = COLOR_ASSEMBLY_FAKEGOLD
 
 /obj/item/clothing/neck/roguetown/chaincoif/AdjustClothes(mob/user)
 	if(loc == user)

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -60,6 +60,11 @@
 	anvilrepair = /datum/skill/craft/armorsmithing
 	smeltresult = /obj/item/ingot/steel
 
+/obj/item/clothing/neck/roguetown/chaincoif/fakegold
+	name = "golden chain coif"
+	desc = "A normal steel coif painted yellow in an attempt to mimic gold."
+	color = COLOR_ASSEMBLY_YELLOW
+
 /obj/item/clothing/neck/roguetown/chaincoif/AdjustClothes(mob/user)
 	if(loc == user)
 		if(adjustable == CAN_CADJUST)

--- a/code/modules/clothing/rogueclothes/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage.dm
@@ -257,7 +257,7 @@
 		STR.not_while_equipped = TRUE
 		STR.allow_dump_out = TRUE
 
-obj/item/storage/belt/rogue/leather/exoticsilkbelt
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt
 	name = "Exotic Silk Belt"
 	desc = "A gold adorned belt with the softest of silks barely concealing one's bits."
 	icon_state = "exoticsilkbelt"

--- a/code/modules/jobs/job_types/roguetown/church/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/church/puritan.dm
@@ -195,7 +195,7 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/sewing, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/tracking, 2, TRUE)
-		H.change_stat("strength", 2)
+		H.change_stat("strength", 3)
 		H.change_stat("endurance", 1)
 		H.change_stat("constitution", 2)
 		H.change_stat("speed", 1)
@@ -218,7 +218,7 @@
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/full
 	wrists = /obj/item/clothing/neck/roguetown/psicross/silver
 	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
-	pants = /obj/item/clothing/under/roguetown/trou/leather
+	pants = /obj/item/clothing/under/roguetown/trou/otavan
 	cloak = /obj/item/clothing/cloak/cape/puritan
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	backl = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
@@ -260,6 +260,7 @@
 		H.change_stat("intelligence", 1)
 
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 
 	return TRUE
 

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -1,15 +1,15 @@
 //shield flail or longsword, tief can be this with red cross
 
 /datum/job/roguetown/templar
-	title = "Templar"
+	title = "Occultist"
 	department_flag = CHURCHMEN
 	faction = "Station"
-	tutorial = "The Templar is a fanatical enforcer tasked with eradicating heresy within the realm, answering only to those who are recognized as true representatives of Psydon: the Inquisitor first, and the priesthood second. Their role is not to interpret the will of Psydon but to enforce the edicts of those granted divine mandate. Any claim of a Templar understanding or interpreting the Psydon will is seen as a violation of their sacred purpose as such presumptions are considered heretical in themselves. Their service is ingrained in them so deeply that their lives are regarded as insignificant in comparison to the sacred duty they bear."
+	tutorial = "You are a fanatical servant of an obscure order, willingly beholden with obeisance to the Inquisitor. In other words, you are a tool of violence wielded against a corrupting evil."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	allowed_patrons = ALL_DIVINE_PATRONS
 	outfit = /datum/outfit/job/roguetown/templar
-	min_pq = 0 //Deus vult, but only according to the proper escalation rules
+	min_pq = 0 
 	max_pq = null
 	round_contrib_points = 2
 	total_positions = 3
@@ -23,10 +23,8 @@
 	has_loadout = TRUE
 	allowed_patrons = ALL_DIVINE_PATRONS
 	belt = /obj/item/storage/belt/rogue/leather/black
-	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
-	beltr = /obj/item/storage/keyring/templar
-	id = /obj/item/clothing/ring/silver
-	backl = /obj/item/storage/backpack/rogue/satchel
+	backr = /obj/item/storage/backpack/rogue/satchel
+	backpack_contents = list(/obj/item/storage/keyring/templar = 1, /obj/item/storage/belt/rogue/pouch/coins/poor = 1)
 
 /datum/job/roguetown/templar/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	..()
@@ -60,10 +58,12 @@
 		// Determine Templar class based on Inquisitor class
 		var/class_type
 		if(!inquisitor_class || inquisitor_class == "random") // Handle random/unset class preference
-			class_type = pick(/datum/advclass/templar/monk, /datum/advclass/templar/crusader)
+			class_type = pick(/datum/advclass/templar/monk, /datum/advclass/templar/crusader, /datum/advclass/templar/hunter)
 		else if(inquisitor_class == "Zealot")
 			class_type = /datum/advclass/templar/monk
-		else // Confessor or Puritan
+		else if(inquisitor_class == "Puritan")
+			class_type = /datum/advclass/templar/hunter
+		else // Confessor
 			class_type = /datum/advclass/templar/crusader
 		
 		chosen_class = new class_type()
@@ -75,17 +75,20 @@
 			qdel(chosen_class)
 
 /datum/advclass/templar/monk
-	name = "Monk"
-	tutorial = "You are a monk of the Church, trained in pugilism and acrobatics. You bear no armor but your faith, and your hands are lethal weapons in service to PSYDON."
+	name = "Practical"
+	tutorial = "You are a warrior-monk in training, pursuing the perfection of body and mind. Your master has lead you along your path, and it is he who will declare it finished. Serve, root corruption from the very soil, and be made better."
 	outfit = /datum/outfit/job/roguetown/templar/monk
 	category_tags = list(CTAG_TEMPLAR)
 
 /datum/outfit/job/roguetown/templar/monk
-	neck = /obj/item/clothing/neck/roguetown/psicross/
-	cloak = /obj/item/clothing/cloak/templar/psydon
-	pants = /obj/item/clothing/under/roguetown/tights/black
-	wrists = /obj/item/clothing/wrists/roguetown/wrappings
-	shoes = /obj/item/clothing/shoes/roguetown/sandals
+	head = /obj/item/clothing/head/roguetown/roguehood
+	neck = /obj/item/clothing/neck/roguetown/psicross/wood
+	shirt = /obj/item/clothing/suit/roguetown/shirt/robe
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
+	beltr = /obj/item/rogueweapon/mace
 
 /datum/advclass/templar/monk/equipme(mob/living/carbon/human/H)
 	if(!H)
@@ -97,75 +100,43 @@
 		O.equip(H)
 
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
 		H.change_stat("strength", 2)
-		H.change_stat("endurance", 2)
+		H.change_stat("endurance", 1)
+		H.change_stat("constitution", 2)
 		H.change_stat("perception", -1)
 
 		ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
-		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
-
-	// Apply patron-specific equipment
-	var/neck_type = /obj/item/clothing/neck/roguetown/psicross/
-	var/cloak_type = /obj/item/clothing/cloak/templar/psydon
-	
-	switch(H.patron?.type)
-		if(/datum/patron/divine/astrata)
-			neck_type = /obj/item/clothing/neck/roguetown/psicross/
-			cloak_type = /obj/item/clothing/cloak/templar/psydon
-		if(/datum/patron/divine/dendor)
-			neck_type = /obj/item/clothing/neck/roguetown/psicross/
-			cloak_type = /obj/item/clothing/cloak/templar/psydon
-		if(/datum/patron/divine/necra)
-			neck_type = /obj/item/clothing/neck/roguetown/psicross/
-			cloak_type = /obj/item/clothing/cloak/templar/psydon
-		if(/datum/patron/divine/pestra)
-			neck_type = /obj/item/clothing/neck/roguetown/psicross/
-			cloak_type = /obj/item/clothing/cloak/templar/psydon
-		if(/datum/patron/divine/noc)
-			neck_type = /obj/item/clothing/neck/roguetown/psicross/
-			cloak_type = /obj/item/clothing/cloak/templar/psydon
-		if(/datum/patron/divine/ravox)
-			neck_type = /obj/item/clothing/neck/roguetown/psicross/
-			cloak_type = /obj/item/clothing/cloak/templar/psydon
-		if(/datum/patron/divine/malum)
-			neck_type = /obj/item/clothing/neck/roguetown/psicross/
-			cloak_type = /obj/item/clothing/cloak/templar/psydon
-		if(/datum/patron/old_god)
-			neck_type = /obj/item/clothing/neck/roguetown/psicross
-			cloak_type = /obj/item/clothing/cloak/tabard/crusader/psydon
-
-	H.equip_to_slot_or_del(new neck_type(H), SLOT_NECK)
-	H.equip_to_slot_or_del(new cloak_type(H), SLOT_CLOAK)
-	H.equip_to_slot_or_del(new /obj/item/clothing/under/roguetown/tights/black(H), SLOT_PANTS)
-	H.equip_to_slot_or_del(new /obj/item/clothing/wrists/roguetown/wrappings(H), SLOT_WRISTS)
-	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/roguetown/sandals(H), SLOT_SHOES)
 
 	return TRUE
 
 /datum/advclass/templar/crusader
-	name = "Templar"
-	tutorial = "You are a templar of the Church, trained in heavy weaponry and zealous warfare. The Inquisitor knows best, or so you believe."
+	name = "Golden Retainer"
+	tutorial = "You are a Golden Retainer, having dedicated your life and service to the Confessor. You subscribe to the ideal of such a savior, chosing to display the golden rays of light upon your armor. It's pretty convincing, too!"
 	outfit = /datum/outfit/job/roguetown/templar/crusader
 	category_tags = list(CTAG_TEMPLAR)
 
 /datum/outfit/job/roguetown/templar/crusader
-	head = /obj/item/clothing/head/roguetown/helmet/sallet/visored
-	neck = /obj/item/clothing/neck/roguetown/psicross/
-	cloak = /obj/item/clothing/cloak/tabard/crusader/psydon
-	gloves = /obj/item/clothing/gloves/roguetown/chain
-	neck = /obj/item/clothing/neck/roguetown/chaincoif
-	pants = /obj/item/clothing/under/roguetown/chainlegs
+	head = /obj/item/clothing/head/roguetown/helmet/heavy/bucket/fakegold
+	neck = /obj/item/clothing/neck/roguetown/chaincoif/fakegold
+	gloves = /obj/item/clothing/gloves/roguetown/chain/fakegold
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	pants = /obj/item/clothing/under/roguetown/trou/leather
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	shoes = /obj/item/clothing/shoes/roguetown/boots
-	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
+	armor = /obj/item/clothing/suit/roguetown/armor/plate/scale/fakegold
+	backl = /obj/item/rogueweapon/shield/tower
+	beltl = /obj/item/rogueweapon/mace/cudgel
+	beltr = /obj/item/rogueweapon/sword/iron
 
 /datum/advclass/templar/crusader/equipme(mob/living/carbon/human/H)
 	if(!H)
@@ -179,99 +150,70 @@
 	if(H.mind)
 		H.virginity = TRUE
 		H.mind.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
-		H.change_stat("strength", 2)
-		H.change_stat("constitution", 2)
-		H.change_stat("endurance", 2)
+		H.change_stat("strength", 1)
+		H.change_stat("constitution", 1)
+		H.change_stat("endurance", 1)
+		H.change_stat("intelligence", 1)
 		H.change_stat("speed", -2)
 
 		ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
-
-	H.equip_to_slot_or_del(new /obj/item/clothing/head/roguetown/helmet/sallet/visored(H), SLOT_HEAD)
-	
-	// Apply patron-specific equipment
-	var/neck_type = /obj/item/clothing/neck/roguetown/psicross/
-	var/cloak_type = /obj/item/clothing/cloak/tabard/crusader/psydon
-	var/wrists_type = /obj/item/clothing/neck/roguetown/psicross/
-	
-	switch(H.patron?.type)
-		if(/datum/patron/divine/astrata)
-			wrists_type = /obj/item/clothing/neck/roguetown/psicross/
-			cloak_type = /obj/item/clothing/cloak/templar/psydon
-		if(/datum/patron/divine/dendor)
-			wrists_type = /obj/item/clothing/neck/roguetown/psicross/
-			cloak_type = /obj/item/clothing/cloak/templar/psydon
-		if(/datum/patron/divine/necra)
-			wrists_type = /obj/item/clothing/neck/roguetown/psicross/
-			cloak_type = /obj/item/clothing/cloak/templar/psydon
-		if(/datum/patron/divine/pestra)
-			wrists_type = /obj/item/clothing/neck/roguetown/psicross/
-			cloak_type = /obj/item/clothing/cloak/templar/psydon
-		if(/datum/patron/divine/noc)
-			wrists_type = /obj/item/clothing/neck/roguetown/psicross/
-			cloak_type = /obj/item/clothing/cloak/templar/psydon
-		if(/datum/patron/divine/ravox)
-			wrists_type = /obj/item/clothing/neck/roguetown/psicross/
-			cloak_type = /obj/item/clothing/cloak/templar/psydon
-		if(/datum/patron/divine/malum)
-			wrists_type = /obj/item/clothing/neck/roguetown/psicross/
-			cloak_type = /obj/item/clothing/cloak/templar/psydon
-		if(/datum/patron/old_god)
-			wrists_type = /obj/item/clothing/neck/roguetown/psicross
-			cloak_type = /obj/item/clothing/cloak/templar/psydon
-
-	H.equip_to_slot_or_del(new neck_type(H), SLOT_NECK)
-	H.equip_to_slot_or_del(new cloak_type(H), SLOT_CLOAK)
-	H.equip_to_slot_or_del(new wrists_type(H), SLOT_WRISTS)
-	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/roguetown/chain(H), SLOT_GLOVES)
-	H.equip_to_slot_or_del(new /obj/item/clothing/neck/roguetown/chaincoif(H), SLOT_NECK)
-	H.equip_to_slot_or_del(new /obj/item/clothing/under/roguetown/chainlegs(H), SLOT_PANTS)
-	H.equip_to_slot_or_del(new /obj/item/clothing/suit/roguetown/armor/gambeson(H), SLOT_SHIRT)
-	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/roguetown/boots(H), SLOT_SHOES)
-	H.equip_to_slot_or_del(new /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk(H), SLOT_ARMOR)
 
 	return TRUE
 
-/datum/outfit/job/roguetown/templar/crusader/choose_loadout(mob/living/carbon/human/H)
-	. = ..()
-	var/weapons = list("Bastard Sword","Flail","Mace")
-	var/weapon_choice = input(H,"Choose your weapon (30 seconds to choose)", "TAKE UP ARMS") as anything in weapons
-	
-	spawn(30 SECONDS)
-		if(!weapon_choice)
-			weapon_choice = pick(weapons)
-			to_chat(H, span_warning("Time's up! Random weapon selected: [weapon_choice]"))
-			switch(weapon_choice)
-				if("Bastard Sword")
-					H.put_in_hands(new /obj/item/rogueweapon/sword/long(H), TRUE)
-					H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
-				if("Flail")
-					H.put_in_hands(new /obj/item/rogueweapon/flail(H), TRUE)
-					H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)
-				if("Mace")
-					H.put_in_hands(new /obj/item/rogueweapon/mace(H), TRUE)
-					H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
-	
-	switch(weapon_choice)
-		if("Bastard Sword")
-			H.put_in_hands(new /obj/item/rogueweapon/sword/long(H), TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
-		if("Flail")
-			H.put_in_hands(new /obj/item/rogueweapon/flail(H), TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)
-		if("Mace")
-			H.put_in_hands(new /obj/item/rogueweapon/mace(H), TRUE)
-			H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
+/datum/advclass/templar/hunter
+	name = "Hunter"
+	tutorial = "You are a monster hunter, having followed the Puritan for some time as a dedicated hunting party. You are entrusted with the silver required to rid the world of the vilest evils."
+	outfit = /datum/outfit/job/roguetown/templar/hunter
+	category_tags = list(CTAG_TEMPLAR)
 
+/datum/outfit/job/roguetown/templar/hunter
+	head = /obj/item/clothing/head/roguetown/puritan
+	mask = /obj/item/clothing/mask/rogue/ragmask
+	neck = /obj/item/clothing/neck/roguetown/psicross/wood
+	gloves = /obj/item/clothing/gloves/roguetown/otavan
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	pants = /obj/item/clothing/under/roguetown/trou/otavan
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/puritan
+	shoes = /obj/item/clothing/shoes/roguetown/boots
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/belted
+	beltr = /obj/item/rogueweapon/sword/iron/messer	
+	beltl = /obj/item/rogueweapon/huntingknife/idagger/silver
+
+/datum/advclass/templar/hunter/equipme(mob/living/carbon/human/H)
+	if(!H)
+		return FALSE
+
+	if(outfit)
+		var/datum/outfit/O = new outfit
+		O.equip(H)
+
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/tracking, 3, TRUE)
+		H.change_stat("strength", 1)
+		H.change_stat("endurance", 1)
+		H.change_stat("intelligence", -1)
+		H.change_stat("speed", 1)
+
+		ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
+
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Renames Templar to Occultist.
Implements 3 Occultist subclasses. These subclasses depend entirely on the class that the Inquisitor picks and cannot otherwise be customized.
Confessor Inquisitor:
The Golden Retainers. Receives a "unique" set of "golden" armor, poorish skills but heavy armor training. Sword, cudgel, and tower shield.
![image](https://github.com/user-attachments/assets/ae6192cb-5dfe-4a79-ad58-e0d5de01118b)
Zealot Inquisitor:
The Practicals. Receives leather armor and a monk robe, as well as a mace. Expert skills. Dodge expert trait.
![image](https://github.com/user-attachments/assets/6e08521f-b798-4af7-b141-5ca1535d0b8f)
Puritan Inquisitor:
The Hunters. Also receives leather armor and puritan clothing minus the cape, as well as a messer and silver dagger. Guard-level skills but with expert swordfighting. Also receives medium armor training and the steelhearted trait.
![image](https://github.com/user-attachments/assets/a145d4fd-2d40-469a-bd51-d9977ba89991)

Furthermore buffs Inquisitor by giving Zealot +1 Str and Puritan the steelhearted trait.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Inquisitor's retinue actually matches what they are and makes them easily identifiable.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
