### PR TITLE
Bleeding rebalance and priest churn undead

### DIFF
--- a/code/datums/wounds/types/arteries.dm
+++ b/code/datums/wounds/types/arteries.dm
@@ -45,7 +45,7 @@
 	crit_message = "Blood sprays from %VICTIM's throat!"
 	whp = 100
 	sewn_whp = 25
-	bleed_rate = 50
+	bleed_rate = 55
 	sewn_bleed_rate = 0.5
 	woundpain = 60
 	sewn_woundpain = 30
@@ -65,7 +65,7 @@
 	severity = WOUND_SEVERITY_FATAL
 	whp = 100
 	sewn_whp = 35
-	bleed_rate = 50
+	bleed_rate = 45
 	sewn_bleed_rate = 0.8
 	woundpain = 100
 	sewn_woundpain = 50
@@ -100,7 +100,7 @@
 	severity = WOUND_SEVERITY_FATAL
 	whp = 100
 	sewn_whp = 25
-	bleed_rate = 50
+	bleed_rate = 45
 	sewn_bleed_rate = 0.5
 	woundpain = 60
 	sewn_woundpain = 30

--- a/code/datums/wounds/types/arteries.dm
+++ b/code/datums/wounds/types/arteries.dm
@@ -6,7 +6,7 @@
 	sound_effect = 'sound/combat/crit.ogg'
 	whp = 50
 	sewn_whp = 20
-	bleed_rate = 20
+	bleed_rate = 25
 	sewn_bleed_rate = 0.2
 	clotting_threshold = null
 	sewn_clotting_threshold = null
@@ -45,7 +45,7 @@
 	crit_message = "Blood sprays from %VICTIM's throat!"
 	whp = 100
 	sewn_whp = 25
-	bleed_rate = 55
+	bleed_rate = 60
 	sewn_bleed_rate = 0.5
 	woundpain = 60
 	sewn_woundpain = 30
@@ -65,7 +65,7 @@
 	severity = WOUND_SEVERITY_FATAL
 	whp = 100
 	sewn_whp = 35
-	bleed_rate = 45
+	bleed_rate = 50
 	sewn_bleed_rate = 0.8
 	woundpain = 100
 	sewn_woundpain = 50

--- a/code/datums/wounds/types/dismemberment.dm
+++ b/code/datums/wounds/types/dismemberment.dm
@@ -4,7 +4,7 @@
 	severity = WOUND_SEVERITY_CRITICAL
 	whp = 75
 	sewn_whp = 25
-	bleed_rate = 25
+	bleed_rate = 50
 	sewn_bleed_rate = 0.25
 	clotting_threshold = null
 	sewn_clotting_threshold = null

--- a/code/datums/wounds/types/dismemberment.dm
+++ b/code/datums/wounds/types/dismemberment.dm
@@ -4,7 +4,7 @@
 	severity = WOUND_SEVERITY_CRITICAL
 	whp = 75
 	sewn_whp = 25
-	bleed_rate = 50
+	bleed_rate = 80
 	sewn_bleed_rate = 0.25
 	clotting_threshold = null
 	sewn_clotting_threshold = null

--- a/code/datums/wounds/types/slashes.dm
+++ b/code/datums/wounds/types/slashes.dm
@@ -50,7 +50,7 @@
 	sound_effect = 'sound/combat/crit2.ogg'
 	whp = 100
 	sewn_whp = 35
-	bleed_rate = 20
+	bleed_rate = 55
 	sewn_bleed_rate = 0.8
 	clotting_rate = 0.02
 	sewn_clotting_rate = 0.02

--- a/code/datums/wounds/types/slashes.dm
+++ b/code/datums/wounds/types/slashes.dm
@@ -50,7 +50,7 @@
 	sound_effect = 'sound/combat/crit2.ogg'
 	whp = 100
 	sewn_whp = 35
-	bleed_rate = 55
+	bleed_rate = 60
 	sewn_bleed_rate = 0.8
 	clotting_rate = 0.02
 	sewn_clotting_rate = 0.02

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -15,7 +15,7 @@
 	tutorial = "The Divine is all that matters in a world of the immoral, and you will preach His wisdom to any who still heed His will. The faithless are growing in number. It is up to you to shepard them toward a God-fearing future; for you are a priest of PSYDON."
 	whitelist_req = FALSE
 
-	spells = list(/obj/effect/proc_holder/spell/invoked/lesser_heal, /obj/effect/proc_holder/spell/invoked/cure_rot, /obj/effect/proc_holder/spell/self/convertrole/templar, /obj/effect/proc_holder/spell/self/convertrole/monk)
+	spells = list(/obj/effect/proc_holder/spell/invoked/lesser_heal, /obj/effect/proc_holder/spell/targeted/churn, /obj/effect/proc_holder/spell/self/convertrole/templar, /obj/effect/proc_holder/spell/self/convertrole/monk)
 	outfit = /datum/outfit/job/roguetown/priest
 
 	display_order = JDO_PRIEST

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -130,9 +130,9 @@
 				remove_status_effect(/datum/status_effect/debuff/bleeding)
 				apply_status_effect(/datum/status_effect/debuff/bleedingworst)
 		if(blood_volume <= BLOOD_VOLUME_BAD)
-			adjustOxyLoss(0.5)
+			adjustOxyLoss(1)
 			if(blood_volume <= BLOOD_VOLUME_SURVIVE)
-				adjustOxyLoss(1)
+				adjustOxyLoss(1.75)
 	else
 		remove_status_effect(/datum/status_effect/debuff/bleeding)
 		remove_status_effect(/datum/status_effect/debuff/bleedingworse)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -130,9 +130,9 @@
 				remove_status_effect(/datum/status_effect/debuff/bleeding)
 				apply_status_effect(/datum/status_effect/debuff/bleedingworst)
 		if(blood_volume <= BLOOD_VOLUME_BAD)
-			adjustOxyLoss(1)
+			adjustOxyLoss(0.5)
 			if(blood_volume <= BLOOD_VOLUME_SURVIVE)
-				adjustOxyLoss(2)
+				adjustOxyLoss(1)
 	else
 		remove_status_effect(/datum/status_effect/debuff/bleeding)
 		remove_status_effect(/datum/status_effect/debuff/bleedingworse)

--- a/code/modules/spells/roguetown/acolyte/necra.dm
+++ b/code/modules/spells/roguetown/acolyte/necra.dm
@@ -44,7 +44,7 @@
 	invocation = "Psydon HATES you!"
 	invocation_type = "shout" //can be none, whisper, emote and shout
 	miracle = TRUE
-	devotion_cost = 20
+	devotion_cost = 10
 
 /obj/effect/proc_holder/spell/targeted/churn/cast(list/targets,mob/living/user = usr)
 	var/prob2explode = 100
@@ -77,7 +77,7 @@
 			if(prob(vamp_prob))
 				explosion(get_turf(L), light_impact_range = 1, flame_range = 1, smoke = FALSE)
 				L.Stun(50)
-//				L.throw_at(get_ranged_target_turf(L, get_dir(user,L), 7), 7, 1, L, spin = FALSE)
+				L.throw_at(get_ranged_target_turf(L, get_dir(user,L), 7), 7, 1, L, spin = FALSE)
 			else
 				L.visible_message(span_warning("[L] resists being churned!"), span_userdanger("I resist being churned!"))
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
All arterial bleeds now bleed slightly more. In particular, carotic(neck) and disembowels bleeds a bit more, while dismembers will drain blood extremely fast. Re-attaching a limb will cause the wound to bleed very slightly less.(you still have to sew it together)

The oxyloss from low blood has been halved, meaning you will die from low blood half as fast.

Also replaces cure rot with churn undead in the priest's spell list. Churn undead now throws your target away from you when it explodes them because its awesome.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Idk, we'll see how it goes
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
