### PR TITLE
Kobolds no longer roundstart playable

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/kobold.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/kobold.dm
@@ -104,7 +104,7 @@
 	)
 
 /datum/species/kobold/check_roundstart_eligible()
-	return TRUE
+	return FALSE
 
 /datum/species/kobold/qualifies_for_rank(rank, list/features)
 	return TRUE


### PR DESCRIPTION

## About The Pull Request
Removes kobolds from the roundstart race selection.
## Why It's Good For The Game

They're ugly and look like shit. 
![image](https://github.com/user-attachments/assets/cfa9cca7-f5f6-4ac0-a690-e21af66e75b1)
