### PR TITLE
Role restructure

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -4964,8 +4964,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/manor)
 "eHX" = (
-/obj/structure/chair/wood/rogue/throne,
-/turf/open/floor/rogue/wood,
+/obj/effect/landmark/start/huskar,
+/turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor)
 "eIt" = (
 /obj/machinery/light/rogue/firebowl/stump,
@@ -5101,6 +5101,10 @@
 "eSe" = (
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors)
+"eSw" = (
+/obj/effect/landmark/start/huskar,
+/turf/open/floor/rogue/carpet/lord/right,
+/area/rogue/indoors/town/manor)
 "eTc" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood{
@@ -8783,9 +8787,6 @@
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "iDm" = (
@@ -10809,7 +10810,6 @@
 "kIp" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/closet/crate/chest/old_crate,
-/obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /turf/open/floor/rogue/blocks,
@@ -12986,8 +12986,14 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/bath)
 "mIm" = (
-/obj/effect/landmark/start/huskar,
-/turf/open/floor/rogue/wood,
+/obj/structure/mineral_door/wood/fancywood{
+	name = "Heir's Apartment";
+	lockid = "heir";
+	locked = 1
+	},
+/turf/open/floor/rogue/ruinedwood{
+	icon_state = "weird1"
+	},
 /area/rogue/indoors/town/manor)
 "mIn" = (
 /obj/machinery/light/rogue/firebowl/stump,
@@ -14618,9 +14624,6 @@
 	},
 /area/rogue/indoors/town/magician)
 "ogx" = (
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
 /obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
 /obj/structure/closet/crate/chest/old_crate,
 /obj/machinery/light/rogue/torchholder/c,
@@ -16820,7 +16823,8 @@
 "qhq" = (
 /obj/structure/mineral_door/wood/fancywood{
 	name = "Lord's Apartment";
-	lockid = "royal"
+	lockid = "royal";
+	locked = 1
 	},
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
@@ -22836,10 +22840,6 @@
 "wyH" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
 "wyI" = (
@@ -67733,7 +67733,7 @@ iFR
 vcT
 xac
 fJE
-jQT
+kts
 fAW
 wKp
 cYQ
@@ -67891,7 +67891,7 @@ vcT
 apq
 xac
 foh
-nJG
+eHX
 jbx
 nJG
 nJG
@@ -68205,7 +68205,7 @@ vcT
 apq
 xac
 lHD
-boY
+eSw
 eTw
 boY
 boY
@@ -68517,8 +68517,8 @@ vyY
 fGv
 vcT
 xac
-eHX
-mIm
+jQT
+fAW
 fAW
 rQI
 lUr
@@ -93644,7 +93644,7 @@ vcT
 vcT
 vcT
 vcT
-mvF
+mIm
 vcT
 vcT
 vcT
@@ -94424,7 +94424,7 @@ qhb
 qhb
 nkZ
 vcT
-mvF
+mIm
 vcT
 vcT
 wSl
@@ -94740,7 +94740,7 @@ oKl
 hBv
 ntE
 jnW
-mvF
+mIm
 lbj
 dPO
 wLg

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -239,8 +239,8 @@
 
 #define JDO_GUARD_CAPTAIN 8
 #define JDO_KNIGHT 8.1
-#define JDO_SQUIRE 8.2
-#define JDO_CASTLEGUARD 8.3
+#define JDO_CASTLEGUARD 8.2
+#define JDO_SQUIRE 8.3
 #define JDO_GATEMASTER 8.4
 #define JDO_SHERIFF 8.5
 #define JDO_TOWNGUARD 8.6

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -100,8 +100,8 @@
 #define LORD		(1<<0)
 #define LADY		(1<<1)
 #define HAND		(1<<2)
-#define STEWARD		(1<<3)
-#define HUSKAR		(1<<4)
+#define HUSKAR		(1<<3)
+#define STEWARD		(1<<4)
 #define KNIGHT		(1<<5)
 #define GUARD_CAPTAIN		(1<<6)
 #define MARSHAL		(1<<7)
@@ -221,11 +221,11 @@
 #define JDO_LADY 1.1
 #define JDO_PRINCE 1.2
 #define JDO_HAND 2
+#define JDO_HUSKAR 2.5
 #define JDO_STEWARD 3
 #define JDO_CLERK 3.1
 #define JDO_MARSHAL 4
 #define JDO_COUNCILLOR 4.1
-#define JDO_HUSKAR 4.2
 
 
 // Courtiers

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -121,7 +121,7 @@ SUBSYSTEM_DEF(job)
 				player.client.prefs.job_preferences[rank] = 0  // Set preference to 0 instead of removing
 				to_chat(player, "<span class='warning'>You have been removed from Occultist selection as there is no Inquisitor.</span>")
 				return FALSE
-
+		/* Depreciated since Huskar was changed from the Consort's bodyguard into the Baron's knight.
 		// Check for Huskar requirements
 		if(job.title == "Huskar")
 			var/consort_exists = FALSE
@@ -134,6 +134,7 @@ SUBSYSTEM_DEF(job)
 				player.client.prefs.job_preferences[job.title] = 0
 				to_chat(player, "<span class='warning'>You have been removed from Huskar selection as there is no Consort.</span>")
 				return FALSE
+			*/
 
 		var/position_limit = job.total_positions
 		if(!latejoin)

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -155,7 +155,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	icon_state = "arrow"
 
 /obj/effect/landmark/start/guard_captain
-	name = "Knight Banneret"
+	name = "Guard Captain"
 	icon_state = "arrow"
 
 /obj/effect/landmark/start/barkeep

--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -109,8 +109,8 @@
 	lockid = "vault"
 
 /obj/item/roguekey/sheriff
-	name = "knight banneret's key"
-	desc = "This key belongs to the knight banneret."
+	name = "huskar's key"
+	desc = "This key belongs to the Huskar."
 	icon_state = "cheesekey"
 	lockid = "sheriff"
 

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -78,9 +78,11 @@
 				return
 				
 			// Check if target is a blackguard
+			/* Disabled along with Knight Banneret and Lieutenant
 			if(H.job in list("Blackguard Lieutenant", "Blackguard Banneret"))
 				to_chat(user, span_warning("The rod's power seems ineffective against the blackguard!"))
 				return
+			*/
 
 			// Check if target is NOT a garrison role(+jester)
 			if(!(H.job in list("Dungeoneer", "Town Guard", "Sergeant at Arms", "Knight Banneret", "Knight Lieutenant", "Jester", "Warden", "Gatemaster", "Squire")))

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -78,11 +78,9 @@
 				return
 				
 			// Check if target is a blackguard
-			/* Disabled along with Knight Banneret and Lieutenant
 			if(H.job in list("Blackguard Lieutenant", "Blackguard Banneret"))
 				to_chat(user, span_warning("The rod's power seems ineffective against the blackguard!"))
 				return
-			*/
 
 			// Check if target is NOT a garrison role(+jester)
 			if(!(H.job in list("Dungeoneer", "Town Guard", "Sergeant at Arms", "Knight Banneret", "Knight Lieutenant", "Jester", "Warden", "Gatemaster", "Squire")))

--- a/code/modules/jobs/job_types/roguetown/church/churchguard.dm
+++ b/code/modules/jobs/job_types/roguetown/church/churchguard.dm
@@ -2,8 +2,8 @@
 	title = "Templar"
 	department_flag = CHURCHMEN
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	allowed_races = RACES_CHURCH
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -12,8 +12,8 @@
 	min_pq = 0 
 	max_pq = null
 	round_contrib_points = 2
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 2
+	spawn_positions = 2
 	advclass_cat_rolls = list(CTAG_TEMPLAR = 20)
 	display_order = JDO_TEMPLAR
 	zizo_roll = 100

--- a/code/modules/jobs/job_types/roguetown/courtier/butler.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/butler.dm
@@ -4,8 +4,8 @@
 	flag = BUTLER
 	department_flag = COURTIERS
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 
 	allowed_races = RACES_ALL_KINDS
 	//allowed_ages = list(AGE_MIDDLEAGED, AGE_OLD)

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard.dm
@@ -3,8 +3,8 @@
 	flag = MANATARMS
 	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	zizo_roll = 75
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS

--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -3,8 +3,8 @@
 	flag = GUARDSMAN
 	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 3
+	spawn_positions = 3
 	selection_color = JCOLOR_SOLDIER
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
@@ -157,7 +157,7 @@
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/roguetown/helmet/kettle(H), SLOT_HEAD)
-	H.equip_to_slot_or_del(new /obj/item/clothing/suit/roguetown/armor/chainmail(H), SLOT_ARMOR)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/roguetown/armor/chainmail/iron(H), SLOT_ARMOR)
 	H.equip_to_slot_or_del(new /obj/item/rogueweapon/mace/cudgel(H), SLOT_BELT_R)
 	H.equip_to_slot_or_del(new /obj/item/rogueweapon/shield/wood(H), SLOT_BACK_R)
 	H.equip_to_slot_or_del(new /obj/item/storage/keyring/guardcastle(H), SLOT_BELT_L)

--- a/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
@@ -3,8 +3,8 @@
 	flag = ELDER
 	department_flag = YEOMEN
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS

--- a/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/bailiff.dm
@@ -3,8 +3,8 @@
 	flag = MARSHAL
 	department_flag = NOBLEMEN
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = NOBLE_RACES_TYPES
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -3,8 +3,8 @@
 	flag = GUARD_CAPTAIN
 	department_flag = NOBLEMEN
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	zizo_roll = 100
 	allowed_races = NOBLE_RACES_TYPES
 	allowed_sexes = list(MALE, FEMALE)
@@ -95,6 +95,7 @@
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 	H.verbs |= /mob/proc/haltyell
 
+/* Given to Huskar instead
 /obj/effect/proc_holder/spell/self/convertrole
 	name = "Recruit Beggar"
 	desc = "Recruit someone to your cause."
@@ -189,8 +190,10 @@
 // used for blackguards event
 /datum/job/roguetown/blackguard_banneret
 	title = "Blackguard Banneret"
-	flag = GUARD_CAPTAIN
+	flag = HUSKAR
 	department_flag = NOBLEMEN
 	faction = "Station"
 	total_positions = 0
 	spawn_positions = 0
+
+*/

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -1,17 +1,16 @@
 /datum/job/roguetown/captain
-	title = "Knight Banneret"
+	title = "Guard Captain"
 	flag = GUARD_CAPTAIN
-	department_flag = NOBLEMEN
+	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 0
-	spawn_positions = 0
-	zizo_roll = 100
-	allowed_races = NOBLE_RACES_TYPES
+	total_positions = 1
+	spawn_positions = 1
+	zizo_roll = 80
+	allowed_races = RACES_ALL_KINDS
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
-	tutorial = "The Knight Banneret is the Baron's most devoted servant, a position of trust earned through a lifetime of unwavering loyalty and proven skill. Answering only to the nobility, they oversee the defense of the realm and the enforcement of the court's decrees with ruthless efficiency. Among the commoners, they are both feared and respected as an incorruptible force, but it is also well known that their dedication has led them to commit terrible acts in the name of the Barony, deeds they view not as atrocities, but as necessary measures to uphold the order they believe in."
+	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
+	tutorial = "You command the Town Guard to protect your Lord's holdings and ensure the preservation of its assets. You answer to the Baron, the Huskar, and the law. Discipline and train the Guardsmen from disorganized embarrassments into proud servants of the Baron's will."
 	display_order = JDO_GUARD_CAPTAIN
-	allowed_patrons = ALL_DIVINE_PATRONS
 	whitelist_req = FALSE
 
 	spells = list(/obj/effect/proc_holder/spell/self/convertrole/guard)
@@ -28,74 +27,54 @@
 	. = ..()
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		if(istype(H.cloak, /obj/item/clothing/cloak/cape/guard))
+		if(istype(H.cloak, /obj/item/clothing/cloak/stabard/guard))
 			var/obj/item/clothing/S = H.cloak
 			var/index = findtext(H.real_name, " ")
 			if(index)
 				index = copytext(H.real_name, 1,index)
 			if(!index)
 				index = H.real_name
-			S.name = "banneret cape ([index])"
-		var/prev_real_name = H.real_name
-		var/prev_name = H.name
-		var/honorary = "Ser"
-		if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
-			honorary = "Dame"
-		H.real_name = "[honorary] [prev_real_name]"
-		H.name = "[honorary] [prev_name]"
-
-		for(var/X in peopleknowme)
-			for(var/datum/mind/MF in get_minds(X))
-				if(MF.known_people)
-					MF.known_people -= prev_real_name
-					H.mind.person_knows_me(MF)
+			S.name = "guard tabard ([index])"
 
 /datum/outfit/job/roguetown/captain/pre_equip(mob/living/carbon/human/H)
 	..()
-	head = /obj/item/clothing/head/roguetown/helmet/bascinet/pigface
-	neck = /obj/item/clothing/neck/roguetown/chaincoif
-	armor = /obj/item/clothing/suit/roguetown/armor/plate/halfplateroyalguard
-	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
+	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
+	armor = /obj/item/clothing/suit/roguetown/armor/plate/half
+	head = /obj/item/clothing/head/roguetown/helmet/sallet/visored
 	pants = /obj/item/clothing/under/roguetown/chainlegs
-	gloves = /obj/item/clothing/gloves/roguetown/plate
+	cloak = /obj/item/clothing/cloak/stabard/guard
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
-	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
-	belt = /obj/item/storage/belt/rogue/leather/plaquesilver
-	beltr = /obj/item/rogueweapon/mace/steel
-	beltl = /obj/item/rogueweapon/sword/sabre
-	cloak = /obj/item/clothing/cloak/cape/guard/
-	backl = /obj/item/rogueweapon/shield/tower/metal
+	gloves = /obj/item/clothing/gloves/roguetown/leather
+	neck = /obj/item/clothing/neck/roguetown/chaincoif
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	belt = /obj/item/storage/belt/rogue/leather/black
+	beltl = /obj/item/rogueweapon/mace/cudgel
+	beltr = /obj/item/storage/keyring/guardcastle
+	r_hand = /obj/item/rogueweapon/spear/billhook
 	backr = /obj/item/storage/backpack/rogue/satchel/black
-	backpack_contents = list(/obj/item/storage/keyring/sheriff = 1, /obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
+	backpack_contents = list(/obj/item/rope/chain = 1, /obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/signal_horn = 1)
 	if(H.mind)
-		H.mind.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 5, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/maces, 4, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/shields, 4, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
-		H.change_stat("strength", 4)
-		H.change_stat("perception", 1)
-		H.change_stat("intelligence", 2)
-		H.change_stat("constitution", 2)
-		H.change_stat("endurance", 2)
+		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 1, TRUE)
+		ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+		ADD_TRAIT(H, TRAIT_GUARDSMAN, TRAIT_GENERIC)
+		H.change_stat("strength", 2)
+		H.change_stat("intelligence", 1)
+		H.change_stat("constitution", 1)
+		H.change_stat("endurance", 1)
 
-	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
-	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
-	H.verbs |= /mob/proc/haltyell
-
-/* Given to Huskar instead
 /obj/effect/proc_holder/spell/self/convertrole
 	name = "Recruit Beggar"
 	desc = "Recruit someone to your cause."
@@ -185,15 +164,3 @@
 	if(!.)
 		return
 	recruit.verbs |= /mob/proc/haltyell
-
-
-// used for blackguards event
-/datum/job/roguetown/blackguard_banneret
-	title = "Blackguard Banneret"
-	flag = HUSKAR
-	department_flag = NOBLEMEN
-	faction = "Station"
-	total_positions = 0
-	spawn_positions = 0
-
-*/

--- a/code/modules/jobs/job_types/roguetown/nobility/huskar.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/huskar.dm
@@ -8,13 +8,13 @@
 	allowed_races = OTAVAN_RACE_TYPES
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
-	tutorial = "The Huskar is a foreign knight assigned to the unenviable task of ensuring the consort's safety during their diplomatic mission, failure carries dire consequences for both them personally and those they know back home. Behind closed doors, their counsel is sharp and invaluable. In public, they remain subservient to the consort's authority."
+	tutorial = "The Huskar is the Baron's most devoted servant, a position of trust earned through a lifetime of unwavering loyalty and proven skill. Answering only to the nobility, they oversee the defense of the realm and the enforcement of the court's decrees with ruthless efficiency. Among the commoners, they are both feared and respected as an incorruptible force, but it is also well known that their dedication has led them to commit terrible acts in the name of the Barony, deeds they view not as atrocities, but as necessary measures to uphold the order they believe in."
 	display_order = JDO_HUSKAR
 	whitelist_req = TRUE
 	outfit = /datum/outfit/job/roguetown/huskar
-	zizo_roll = 90
-	give_bank_account = 20
-	noble_income = 10
+	zizo_roll = 100
+	give_bank_account = 26
+	noble_income = 16
 	min_pq = 0
 	max_pq = null
 	round_contrib_points = 2
@@ -22,12 +22,10 @@
 	cmode_music = 'sound/music/combat_knight.ogg'
 	family_blacklisted = TRUE
 
-/datum/outfit/job/roguetown/huskar/pre_equip(mob/living/carbon/human/H)
+/datum/job/roguetown/captain/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
-	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
-	if(H.mind)
-
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
 		var/prev_real_name = H.real_name
 		var/prev_name = H.name
 		var/honorary = "Ser"
@@ -36,29 +34,17 @@
 		H.real_name = "[honorary] [prev_real_name]"
 		H.name = "[honorary] [prev_name]"
 
-		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
-		H.change_stat("strength", 1)
-		H.change_stat("endurance", 2)
-		H.change_stat("constitution", 3)
-		H.change_stat("perception", 1)
-		H.change_stat("speed", -1)
+		for(var/X in peopleknowme)
+			for(var/datum/mind/MF in get_minds(X))
+				if(MF.known_people)
+					MF.known_people -= prev_real_name
+					H.mind.person_knows_me(MF)
 
-/datum/outfit/job/roguetown/huskar
+/datum/outfit/job/roguetown/huskar/pre_equip(mob/living/carbon/human/H)
+	..()
 	belt = /obj/item/storage/belt/rogue/leather
-	beltl = /obj/item/storage/keyring/guardcastle
-	beltr = /obj/item/rogueweapon/sword/falchion
+	beltl = /obj/item/rogueweapon/sword/sabre
+	beltr = /obj/item/rogueweapon/mace/steel
 	neck = /obj/item/clothing/neck/roguetown/fencerguard
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/otavan
 	head = /obj/item/clothing/head/roguetown/helmet/otavan
@@ -68,4 +54,119 @@
 	gloves = /obj/item/clothing/gloves/roguetown/otavan
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	backl = /obj/item/rogueweapon/shield/tower/metal
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/rope/chain = 1, /obj/item/storage/belt/rogue/pouch/coins/rich = 1)
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1, /obj/item/storage/keyring/sheriff, /obj/item/storage/belt/rogue/pouch/coins/rich = 1)
+	if(H.mind)
+		H.mind.adjust_skillrank(/datum/skill/combat/maces, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/crossbows, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/shields, 4, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/polearms, 5, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/riding, 3, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+		H.change_stat("strength", 4)
+		H.change_stat("endurance", 2)
+		H.change_stat("constitution", 3)
+		H.change_stat("perception", 1)
+		H.change_stat("speed", -1)
+	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
+	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
+	H.verbs |= /mob/proc/haltyell
+
+	/obj/effect/proc_holder/spell/self/convertrole
+		name = "Recruit Beggar"
+		desc = "Recruit someone to your cause."
+		overlay_state = "recruit_bog"
+		antimagic_allowed = TRUE
+		charge_max = 100
+		/// Role given if recruitment is accepted
+		var/new_role = "Beggar"
+		/// Faction shown to the user in the recruitment prompt
+		var/recruitment_faction = "Beggars"
+		/// Message the recruiter gives
+		var/recruitment_message = "Serve the beggars, %RECRUIT!"
+		/// Range to search for potential recruits
+		var/recruitment_range = 3
+		/// Say message when the recruit accepts
+		var/accept_message = "I will serve!"
+		/// Say message when the recruit refuses
+		var/refuse_message = "I refuse."
+
+	/obj/effect/proc_holder/spell/self/convertrole/cast(list/targets,mob/user = usr)
+		. = ..()
+		var/list/recruitment = list()
+		for(var/mob/living/carbon/human/recruit in (get_hearers_in_view(recruitment_range, user) - user))
+			//not allowed
+			if(!can_convert(recruit))
+				continue
+			recruitment[recruit.name] = recruit
+		if(!length(recruitment))
+			to_chat(user, span_warning("There are no potential recruits in range."))
+			return
+		var/inputty = input(user, "Select a potential recruit!", "[name]") as anything in recruitment
+		if(inputty)
+			var/mob/living/carbon/human/recruit = recruitment[inputty]
+			if(!QDELETED(recruit) && (recruit in get_hearers_in_view(recruitment_range, user)))
+				INVOKE_ASYNC(src, PROC_REF(convert), recruit, user)
+			else
+				to_chat(user, span_warning("Recruitment failed!"))
+		else
+			to_chat(user, span_warning("Recruitment cancelled."))
+
+	/obj/effect/proc_holder/spell/self/convertrole/proc/can_convert(mob/living/carbon/human/recruit)
+		//wtf
+		if(QDELETED(recruit))
+			return FALSE
+		//need a mind
+		if(!recruit.mind)
+			return FALSE
+		//only migrants and peasants
+		if(!(recruit.job in GLOB.peasant_positions) && \
+			!(recruit.job in GLOB.yeoman_positions) && \
+			!(recruit.job in GLOB.allmig_positions) && \
+			!(recruit.job in GLOB.mercenary_positions))
+			return FALSE
+		//need to see their damn face
+		if(!recruit.get_face_name(null))
+			return FALSE
+		return TRUE
+
+	/obj/effect/proc_holder/spell/self/convertrole/proc/convert(mob/living/carbon/human/recruit, mob/living/carbon/human/recruiter)
+		if(QDELETED(recruit) || QDELETED(recruiter))
+			return FALSE
+		recruiter.say(replacetext(recruitment_message, "%RECRUIT", "[recruit]"), forced = "[name]")
+		var/prompt = alert(recruit, "Do you wish to become a [new_role]?", "[recruitment_faction] Recruitment", "Yes", "No")
+		if(QDELETED(recruit) || QDELETED(recruiter) || !(recruiter in get_hearers_in_view(recruitment_range, recruit)))
+			return FALSE
+		if(prompt != "Yes")
+			if(refuse_message)
+				recruit.say(refuse_message, forced = "[name]")
+			return FALSE
+		if(accept_message)
+			recruit.say(accept_message, forced = "[name]")
+		if(new_role)
+			recruit.job = new_role
+		return TRUE
+
+	/obj/effect/proc_holder/spell/self/convertrole/guard
+		name = "Recruit Guardsmen"
+		new_role = "Town Guard"
+		overlay_state = "recruit_guard"
+		recruitment_faction = "Watchman"
+		recruitment_message = "Serve the town guard, %RECRUIT!"
+		accept_message = "FOR THE BARON!"
+		refuse_message = "I refuse."
+
+	/obj/effect/proc_holder/spell/self/convertrole/guard/convert(mob/living/carbon/human/recruit, mob/living/carbon/human/recruiter)
+		. = ..()
+		if(!.)
+			return
+		recruit.verbs |= /mob/proc/haltyell

--- a/code/modules/jobs/job_types/roguetown/nobility/huskar.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/huskar.dm
@@ -26,7 +26,7 @@
 	cmode_music = 'sound/music/combat_knight.ogg'
 	family_blacklisted = TRUE
 
-/datum/job/roguetown/captain/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+/datum/job/roguetown/huskar/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L

--- a/code/modules/jobs/job_types/roguetown/nobility/huskar.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/huskar.dm
@@ -1,4 +1,4 @@
-/datum/job/roguetown/Huskar
+/datum/job/roguetown/huskar
 	title = "Huskar"
 	flag = HUSKAR
 	department_flag = NOBLEMEN
@@ -7,9 +7,10 @@
 	spawn_positions = 1
 	allowed_races = OTAVAN_RACE_TYPES
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
+	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 	tutorial = "The Huskar is the Baron's most devoted servant, a position of trust earned through a lifetime of unwavering loyalty and proven skill. Answering only to the nobility, they oversee the defense of the realm and the enforcement of the court's decrees with ruthless efficiency. Among the commoners, they are both feared and respected as an incorruptible force, but it is also well known that their dedication has led them to commit terrible acts in the name of the Barony, deeds they view not as atrocities, but as necessary measures to uphold the order they believe in."
 	display_order = JDO_HUSKAR
+	allowed_patrons = ALL_DIVINE_PATRONS
 	whitelist_req = TRUE
 	outfit = /datum/outfit/job/roguetown/huskar
 	zizo_roll = 100
@@ -18,6 +19,9 @@
 	min_pq = 0
 	max_pq = null
 	round_contrib_points = 2
+
+	spells = list(/obj/effect/proc_holder/spell/self/convertrole/guard)
+	outfit = /datum/outfit/job/roguetown/huskar
 
 	cmode_music = 'sound/music/combat_knight.ogg'
 	family_blacklisted = TRUE
@@ -81,92 +85,3 @@
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 	H.verbs |= /mob/proc/haltyell
 
-	/obj/effect/proc_holder/spell/self/convertrole
-		name = "Recruit Beggar"
-		desc = "Recruit someone to your cause."
-		overlay_state = "recruit_bog"
-		antimagic_allowed = TRUE
-		charge_max = 100
-		/// Role given if recruitment is accepted
-		var/new_role = "Beggar"
-		/// Faction shown to the user in the recruitment prompt
-		var/recruitment_faction = "Beggars"
-		/// Message the recruiter gives
-		var/recruitment_message = "Serve the beggars, %RECRUIT!"
-		/// Range to search for potential recruits
-		var/recruitment_range = 3
-		/// Say message when the recruit accepts
-		var/accept_message = "I will serve!"
-		/// Say message when the recruit refuses
-		var/refuse_message = "I refuse."
-
-	/obj/effect/proc_holder/spell/self/convertrole/cast(list/targets,mob/user = usr)
-		. = ..()
-		var/list/recruitment = list()
-		for(var/mob/living/carbon/human/recruit in (get_hearers_in_view(recruitment_range, user) - user))
-			//not allowed
-			if(!can_convert(recruit))
-				continue
-			recruitment[recruit.name] = recruit
-		if(!length(recruitment))
-			to_chat(user, span_warning("There are no potential recruits in range."))
-			return
-		var/inputty = input(user, "Select a potential recruit!", "[name]") as anything in recruitment
-		if(inputty)
-			var/mob/living/carbon/human/recruit = recruitment[inputty]
-			if(!QDELETED(recruit) && (recruit in get_hearers_in_view(recruitment_range, user)))
-				INVOKE_ASYNC(src, PROC_REF(convert), recruit, user)
-			else
-				to_chat(user, span_warning("Recruitment failed!"))
-		else
-			to_chat(user, span_warning("Recruitment cancelled."))
-
-	/obj/effect/proc_holder/spell/self/convertrole/proc/can_convert(mob/living/carbon/human/recruit)
-		//wtf
-		if(QDELETED(recruit))
-			return FALSE
-		//need a mind
-		if(!recruit.mind)
-			return FALSE
-		//only migrants and peasants
-		if(!(recruit.job in GLOB.peasant_positions) && \
-			!(recruit.job in GLOB.yeoman_positions) && \
-			!(recruit.job in GLOB.allmig_positions) && \
-			!(recruit.job in GLOB.mercenary_positions))
-			return FALSE
-		//need to see their damn face
-		if(!recruit.get_face_name(null))
-			return FALSE
-		return TRUE
-
-	/obj/effect/proc_holder/spell/self/convertrole/proc/convert(mob/living/carbon/human/recruit, mob/living/carbon/human/recruiter)
-		if(QDELETED(recruit) || QDELETED(recruiter))
-			return FALSE
-		recruiter.say(replacetext(recruitment_message, "%RECRUIT", "[recruit]"), forced = "[name]")
-		var/prompt = alert(recruit, "Do you wish to become a [new_role]?", "[recruitment_faction] Recruitment", "Yes", "No")
-		if(QDELETED(recruit) || QDELETED(recruiter) || !(recruiter in get_hearers_in_view(recruitment_range, recruit)))
-			return FALSE
-		if(prompt != "Yes")
-			if(refuse_message)
-				recruit.say(refuse_message, forced = "[name]")
-			return FALSE
-		if(accept_message)
-			recruit.say(accept_message, forced = "[name]")
-		if(new_role)
-			recruit.job = new_role
-		return TRUE
-
-	/obj/effect/proc_holder/spell/self/convertrole/guard
-		name = "Recruit Guardsmen"
-		new_role = "Town Guard"
-		overlay_state = "recruit_guard"
-		recruitment_faction = "Watchman"
-		recruitment_message = "Serve the town guard, %RECRUIT!"
-		accept_message = "FOR THE BARON!"
-		refuse_message = "I refuse."
-
-	/obj/effect/proc_holder/spell/self/convertrole/guard/convert(mob/living/carbon/human/recruit, mob/living/carbon/human/recruiter)
-		. = ..()
-		if(!.)
-			return
-		recruit.verbs |= /mob/proc/haltyell

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -422,7 +422,6 @@
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/shield/tower/metal(H), SLOT_BACK_L)
 
 // used for blackguards event
-/* Disabled along with Knight Lieutenant
 /datum/job/roguetown/blackguard_lieutenant
 	title = "Blackguard Lieutenant"
 	flag = KNIGHT
@@ -430,4 +429,3 @@
 	faction = "Station"
 	total_positions = 0 
 	spawn_positions = 0
-*/

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -422,6 +422,7 @@
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/shield/tower/metal(H), SLOT_BACK_L)
 
 // used for blackguards event
+/* Disabled along with Knight Lieutenant
 /datum/job/roguetown/blackguard_lieutenant
 	title = "Blackguard Lieutenant"
 	flag = KNIGHT
@@ -429,3 +430,4 @@
 	faction = "Station"
 	total_positions = 0 
 	spawn_positions = 0
+*/

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -3,8 +3,8 @@
 	flag = KNIGHT
 	department_flag = NOBLEMEN
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	allowed_races = NOBLE_RACES_TYPES
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)

--- a/code/modules/jobs/job_types/roguetown/yeomen/artificer.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/artificer.dm
@@ -3,8 +3,8 @@
 	flag = ARTIFICER
 	department_flag = YEOMEN
 	faction = "Station"
-	total_positions = 3
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 
 	allowed_races = RACES_ALL_KINDS
 	allowed_sexes = list(MALE, FEMALE)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/mage_apprentice.dm
@@ -3,8 +3,8 @@
 	flag = MAGEAPPRENTICE
 	department_flag = YOUNGFOLK
 	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 1
+	spawn_positions = 1
 	zizo_roll = 75
 	allowed_races = RACES_ALL_KINDS
 	allowed_ages = list(AGE_YOUNG, AGE_ADULT)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/smith_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/smith_apprentice.dm
@@ -3,8 +3,8 @@
 	flag = APPRENTICE
 	department_flag = YOUNGFOLK
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 
 	allowed_races = RACES_ALL_KINDS
 	allowed_ages = list(AGE_YOUNG, AGE_ADULT)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/smith_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/smith_apprentice.dm
@@ -3,8 +3,8 @@
 	flag = APPRENTICE
 	department_flag = YOUNGFOLK
 	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 1
+	spawn_positions = 1
 
 	allowed_races = RACES_ALL_KINDS
 	allowed_ages = list(AGE_YOUNG, AGE_ADULT)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
@@ -3,8 +3,8 @@
 	flag = SQUIRE
 	department_flag = YOUNGFOLK
 	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 1
+	spawn_positions = 1
 	allowed_races = RACES_ALL_KINDS
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_YOUNG, AGE_ADULT)

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -64,7 +64,7 @@ GLOBAL_LIST_INIT(noble_positions, list(
 	"Consort",
 	"Heir",
 	"Hand",
-	"Knight Banneret",
+
 	"Magistrate",
 	"Councillor",
 	"Steward",
@@ -80,6 +80,7 @@ GLOBAL_LIST_INIT(courtier_positions, list(
 ))
 
 GLOBAL_LIST_INIT(garrison_positions, list(
+	"Guard Captain",
 	"Town Guard",
 	"Warden",
 	"Bog Master",

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -304,7 +304,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 			if(!inquisitor_exists)
 				to_chat(src, "<span class='warning'>There must be or have been an Inquisitor for you to join as Occultist!</span>")
 				return
-
+		/* Depreciated since Huskar was changed from the Consort's bodyguard into the Baron's knight.
 		if(href_list["SelectedJob"] == "Huskar")
 			// Check for consort
 			var/mob/living/carbon/human/consort
@@ -316,7 +316,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 			if(!consort)
 				to_chat(src, "<span class='warning'>There must be a Consort for you to join as Huskar!</span>")
 				return
-
+		*/
 		if(!SSticker?.IsRoundInProgress())
 			to_chat(usr, span_danger("The round is either not ready, or has already finished..."))
 			return

--- a/modular_hearthstone/code/game/objects/items/signal_horn.dm
+++ b/modular_hearthstone/code/game/objects/items/signal_horn.dm
@@ -17,9 +17,9 @@
 	switch(user.job)
 		if("Warden")
 			playsound(src, 'modular_hearthstone/sound/items/bogguardhorn.ogg', 100, TRUE)
-		if("Town Sheriff", "Town Guard")
+		if("Town Sheriff", "Town Guard", "Guard Captain")
 			playsound(src, 'modular_hearthstone/sound/items/watchhorn.ogg', 100, TRUE)
-		if("Sergeant at Arms", "Knight Lieutenant")
+		if("Sergeant at Arms", "Knight Lieutenant", "Huskar")
 			playsound(src, 'modular_hearthstone/sound/items/rghorn.ogg', 100, TRUE)
 		else
 			playsound(src, 'modular_hearthstone/sound/items/signalhorn.ogg', 100, TRUE)

--- a/modular_penumbra/aspect.dm
+++ b/modular_penumbra/aspect.dm
@@ -606,7 +606,7 @@ GLOBAL_DATUM_INIT(SSroundstart_events, /datum/controller/subsystem/roundstart_ev
 /datum/round_event_control/roundstart/blackguards
 	name = "Blackguards"
 	typepath = /datum/round_event/roundstart/blackguards
-	weight = 5
+	weight = 0
 	event_announcement = "With the Baron's finest knights slain in battle, he has been forced to hire Blackguard mercenaries to lead his forces. They are less loyal, but their skill and cruelty is well proven.."
 	runnable = TRUE
 

--- a/modular_penumbra/aspect.dm
+++ b/modular_penumbra/aspect.dm
@@ -488,7 +488,7 @@ GLOBAL_DATUM_INIT(SSroundstart_events, /datum/controller/subsystem/roundstart_ev
 	runnable = TRUE
 
 //Blackguards event
-
+/* Disabled along with Knight Banneret & Lieutenant
 /datum/antagonist/blackguard
 	name = "Blackguard"
 	roundend_category = "blackguards"
@@ -609,7 +609,7 @@ GLOBAL_DATUM_INIT(SSroundstart_events, /datum/controller/subsystem/roundstart_ev
 	weight = 5
 	event_announcement = "With the Baron's finest knights slain in battle, he has been forced to hire Blackguard mercenaries to lead his forces. They are less loyal, but their skill and cruelty is well proven.."
 	runnable = TRUE
-
+*/
 
 //Traitor guard event
 /datum/antagonist/traitor_guard

--- a/modular_penumbra/aspect.dm
+++ b/modular_penumbra/aspect.dm
@@ -488,7 +488,7 @@ GLOBAL_DATUM_INIT(SSroundstart_events, /datum/controller/subsystem/roundstart_ev
 	runnable = TRUE
 
 //Blackguards event
-/* Disabled along with Knight Banneret & Lieutenant
+
 /datum/antagonist/blackguard
 	name = "Blackguard"
 	roundend_category = "blackguards"
@@ -609,7 +609,7 @@ GLOBAL_DATUM_INIT(SSroundstart_events, /datum/controller/subsystem/roundstart_ev
 	weight = 5
 	event_announcement = "With the Baron's finest knights slain in battle, he has been forced to hire Blackguard mercenaries to lead his forces. They are less loyal, but their skill and cruelty is well proven.."
 	runnable = TRUE
-*/
+
 
 //Traitor guard event
 /datum/antagonist/traitor_guard


### PR DESCRIPTION
## About The Pull Request

### Garrison
- Knight Banneret disabled. Huskar replaces Banneret. Hukar's stats and skills buffed to parity.
- Knight Lieutenant disabled.
- Sergeant at Arms is now the Guard Captain.
- Squires reduced from 2 slots to 1 slot.
- Town Guards reduced from 4 slots to 3 slots.
- Town Guard Footman armor nerfed from steel haubergeon to iron chainmail.
- Guard Captain given chain legs, a hauberk, halfplate, and a visored sallet.
- Guard Captain given a billhook and Polearms 4.
- Both Huskar and Guard Captain have the ability to recruit guardsmen.
Garrison role list is now:
1 Huskar 
1 Guard Captain
3 Town Guards
1 Squire

### Court
- Magistrate disabled.
- Head Maid disabled.
- Magician's Apprentice reduced to 1 slot.

### Church 
- Templar disabled.
- Occultist reduced from 3 slots to 2 slots.

### Town
- Artificer disabled.
- Smithy Apprentice disabled.
- Town Elder disabled.

This PR also sets the doors for the Lord's and Heirs' apartments to start locked. It also reduces the amount of hardtack and potions in the garrison.
