### PR TITLE
Bathmaster Stuff

### DIFF
--- a/_maps/map_files/dun_manor/dun_manor.dmm
+++ b/_maps/map_files/dun_manor/dun_manor.dmm
@@ -9456,6 +9456,13 @@
 	},
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town)
+"jlX" = (
+/obj/structure/roguemachine/drugmachine{
+	pixel_y = 32;
+	density = 0
+	},
+/turf/open/floor/rogue/hexstone,
+/area/rogue/indoors/town/bath)
 "jlY" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/wrists/roguetown/bracers/leather,
@@ -21286,11 +21293,12 @@
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/indoors)
 "uGz" = (
-/obj/structure/roguemachine/drugmachine{
-	pixel_y = 32;
-	density = 0
+/obj/structure/roguemachine/atm{
+	mammonsiphoned = 250;
+	pixel_y = 0;
+	pixel_x = -32
 	},
-/turf/open/floor/rogue/blocks/stonered,
+/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
 "uHq" = (
 /obj/structure/flora/roguegrass/bush,
@@ -28824,7 +28832,7 @@ gFr
 hqB
 ngC
 ngC
-ngC
+uGz
 dhw
 soL
 puG
@@ -28978,7 +28986,7 @@ tyl
 hpC
 fVT
 kAA
-ngC
+jlX
 ngC
 ngC
 ngC
@@ -29764,7 +29772,7 @@ umZ
 umZ
 kAA
 kAA
-uGz
+pUC
 ktR
 ktR
 aPv

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -5,6 +5,8 @@
 	icon_state = "spice"
 	item_state = "spice"
 	possible_transfer_amounts = list()
+	list_reagents = list(/datum/reagent/druqks = 66)
+	grind_results = list(/datum/reagent/druqks = 66)
 	volume = 15
 	sellprice = 10
 

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -45,6 +45,7 @@
 	if(M.has_flaw(/datum/charflaw/addiction/junkie))
 		M.sate_addiction()
 	M.apply_status_effect(/datum/status_effect/buff/druqks)
+	M.rogstam_add(25)
 	..()
 
 /atom/movable/screen/fullscreen/druqks

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -302,6 +302,7 @@
 	if(M.has_flaw(/datum/charflaw/addiction/junkie))
 		M.sate_addiction()
 	M.apply_status_effect(/datum/status_effect/buff/moondust_purest)
+	M.rogstam_add(10)
 	if(prob(20))
 		M.flash_fullscreen("whiteflash")
 	..()
@@ -317,8 +318,8 @@
 	icon_state = "moondust"
 	possible_transfer_amounts = list()
 	volume = 15
-	list_reagents = list(/datum/reagent/moondust = 15)
-	grind_results = list(/datum/reagent/moondust = 15)
+	list_reagents = list(/datum/reagent/moondust_purest = 15)
+	grind_results = list(/datum/reagent/moondust_purest = 15)
 	sellprice = 5
 
 /datum/reagent/moondust/overdose_process(mob/living/M)

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -391,8 +391,8 @@
 	item_state = "spice"
 	possible_transfer_amounts = list()
 	volume = 15
-	list_reagents = list(/datum/reagent/druqks = 15)
-	grind_results = list(/datum/reagent/druqks = 15)
+	list_reagents = list(/datum/reagent/druqks = 16)
+	grind_results = list(/datum/reagent/druqks = 16)
 	sellprice = 10
 
 /datum/reagent/druqks

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -252,6 +252,7 @@
 	if(M.has_flaw(/datum/charflaw/addiction/junkie))
 		M.sate_addiction()
 	M.apply_status_effect(/datum/status_effect/buff/moondust)
+	M.rogstam_add(5)
 	if(prob(10))
 		M.flash_fullscreen("whiteflash")
 	..()

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -357,8 +357,8 @@
 	icon_state = "ozium"
 	possible_transfer_amounts = list()
 	volume = 15
-	list_reagents = list(/datum/reagent/ozium = 15)
-	grind_results = list(/datum/reagent/ozium = 15)
+	list_reagents = list(/datum/reagent/ozium_enhanced = 15)
+	grind_results = list(/datum/reagent/ozium_enhanced = 15)
 	sellprice = 5
 
 /datum/reagent/ozium_enhanced

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -21,7 +21,7 @@
 	list_reagents = list(/datum/reagent/water = 48)
 
 /obj/item/reagent_containers/glass/bottle/rogue/sleepy
-	list_reagents = list(/datum/reagent/medicine/sleepy = 45)
+	list_reagents = list(/datum/reagent/medicine/sleepy = 15)
 
 //////////////////////////
 /// ALCOHOLIC BOTTLES ///

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -20,6 +20,9 @@
 /obj/item/reagent_containers/glass/bottle/rogue/water
 	list_reagents = list(/datum/reagent/water = 48)
 
+/obj/item/reagent_containers/glass/bottle/rogue/sleepy
+	list_reagents = list(/datum/reagent/medicine/sleepy = 45)
+
 //////////////////////////
 /// ALCOHOLIC BOTTLES ///
 //////////////////////////

--- a/code/modules/roguetown/roguejobs/alchemist/reagents.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/reagents.dm
@@ -258,3 +258,17 @@
 	if(!status && volume >= min_volume && M.getorganslot(ORGAN_SLOT_PENIS))
 		status = M.apply_status_effect(effect_type, quality)
 	return ..()
+
+/datum/reagent/potion/sleepy
+	name = "Sleeping Potion"
+	description = "An oily substance which induces sleep into its imbibers."
+	silent_toxin = TRUE
+	reagent_state = LIQUID
+	color = "#210707" 
+	toxpwr = 0
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM
+
+/datum/reagent/potion/sleepy/on_mob_life(mob/living/carbon/M)
+			M.Sleeping(40, 0) //Sleep for as long as you've got units of sleepy in you.
+			. = 1
+	..()

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -272,6 +272,7 @@
 	held_items[/obj/item/ammo_casing/caseless/rogue/bolt/pyro] = list("PRICE" = rand(15,35), "NAME" = "oil covered incendiary bolt")
 	held_items[/obj/item/reagent_containers/glass/bottle/rogue/poison] = list("PRICE" = rand(15, 35), "NAME" = "enhanced poison")
 	held_items[/obj/item/book/granter/spell_points] = list("PRICE" = rand(100, 500), "NAME" = "tome of forbidden arcynery")
+	held_items[/obj/item/reagent_containers/glass/bottle/rogue/sleepy] = list("PRICE" = rand(10, 35), "NAME" = "sleeping oil")
 
 #undef DRUGRADE_MONEYA
 #undef DRUGRADE_MONEYB

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -256,6 +256,7 @@
 	held_items[/obj/item/clothing/mask/cigarette/rollie/cannabis] = list("PRICE" = rand(12,18),"NAME" = "swampweed zig")
 	held_items[/obj/item/clothing/mask/cigarette/rollie/nicotine] = list("PRICE" = rand(5,10),"NAME" = "zig")
 	held_items[/obj/item/slimepotion/lovepotion] = list("PRICE" = rand(80,100),"NAME" = "love potion")
+	held_items[/obj/item/clothing/head/roguetown/menacing/bandit] = list("PRICE" = rand(5, 25), "NAME" = "ne'er do 'ell mask")
 
 	// Add enhanced versions with same prices
 	held_items[/obj/item/reagent_containers/powder/spice_enhanced] = list("PRICE" = (41),"NAME" = "enhanced chuckledust")

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -270,6 +270,7 @@
 	held_items[/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow] = list("PRICE" = (30), "NAME" = "enhanced crossbow")
 	held_items[/obj/item/ammo_casing/caseless/rogue/bolt] = list("PRICE" = rand(5, 15), "NAME" = "enhanced bolt")
 	held_items[/obj/item/ammo_casing/caseless/rogue/bolt/pyro] = list("PRICE" = rand(15,35), "NAME" = "oil covered incendiary bolt")
+	held_items[/obj/item/reagent_containers/glass/bottle/rogue/poison] = list("PRICE" = rand(15, 35), "NAME" = "enhanced poison")
 
 #undef DRUGRADE_MONEYA
 #undef DRUGRADE_MONEYB

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -267,6 +267,9 @@
 	held_items[/obj/item/acid_oil] = list("PRICE" = (150),"NAME" = "acid oil")
 	held_items[/obj/item/lockpickring] = list("PRICE" = (15), "NAME" = "oil infused lockpicks")
 	held_items[/obj/item/storage/belt/rogue/surgery_bag/full] = list("PRICE" = (75), "NAME" = "enhanced medical bag")
+	held_items[/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow] = list("PRICE" = (30), "NAME" = "enhanced crossbow")
+	held_items[/obj/item/ammo_casing/caseless/rogue/bolt] = list("PRICE" = rand(5, 15), "NAME" = "enhanced bolt")
+	held_items[/obj/item/ammo_casing/caseless/rogue/bolt/pyro] = list("PRICE" = rand(15,35), "NAME" = "oil covered incendiary bolt")
 
 #undef DRUGRADE_MONEYA
 #undef DRUGRADE_MONEYB

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -265,6 +265,7 @@
 	held_items[/obj/item/fire_oil] = list("PRICE" = (100),"NAME" = "fire Oil")
 	held_items[/obj/item/acid_oil] = list("PRICE" = (150),"NAME" = "acid oil")
 	held_items[/obj/item/lockpickring] = list("PRICE" = (15), "NAME" = "oil infused lockpicks")
+	held_items[/obj/item/storage/belt/rogue/surgery_bag/full] = list("PRICE" = (75), "NAME" = "enhanced medical bag")
 
 #undef DRUGRADE_MONEYA
 #undef DRUGRADE_MONEYB

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -205,7 +205,7 @@
 
 	for(var/I in held_items)
 		// Skip enhanced versions and oils for users without TRAIT_DRUGENHANCER
-		if((!HAS_TRAIT(user, TRAIT_DRUGENHANCER)) && (findtext("[I]", "enhanced") || findtext("[I]", "oil")))
+		if((!HAS_TRAIT(user, TRAIT_DRUGENHANCER)) && (findtext("[I]", "enhanced") || findtext("[I]", "oil") || findtext("[I]", "forbidden")))
 			continue
 
 		var/price = FLOOR(held_items[I]["PRICE"] + (SStreasury.tax_value * held_items[I]["PRICE"]), 1)
@@ -271,6 +271,7 @@
 	held_items[/obj/item/ammo_casing/caseless/rogue/bolt] = list("PRICE" = rand(5, 15), "NAME" = "enhanced bolt")
 	held_items[/obj/item/ammo_casing/caseless/rogue/bolt/pyro] = list("PRICE" = rand(15,35), "NAME" = "oil covered incendiary bolt")
 	held_items[/obj/item/reagent_containers/glass/bottle/rogue/poison] = list("PRICE" = rand(15, 35), "NAME" = "enhanced poison")
+	held_items[/obj/item/book/granter/spell_points] = list("PRICE" = rand(100, 500), "NAME" = "tome of forbidden arcynery")
 
 #undef DRUGRADE_MONEYA
 #undef DRUGRADE_MONEYB

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -254,7 +254,9 @@
 	held_items[/obj/item/reagent_containers/powder/ozium] = list("PRICE" = rand(6,15),"NAME" = "ozium")
 	held_items[/obj/item/reagent_containers/powder/moondust] = list("PRICE" = rand(13,25),"NAME" = "moondust")
 	held_items[/obj/item/clothing/mask/cigarette/rollie/cannabis] = list("PRICE" = rand(12,18),"NAME" = "swampweed zig")
+	held_items[/obj/item/reagent_containers/food/snacks/grown/rogue/sweetleafdry] = list("PRICE" = rand(12,18), "NAME" = "dry swampweed")
 	held_items[/obj/item/clothing/mask/cigarette/rollie/nicotine] = list("PRICE" = rand(5,10),"NAME" = "zig")
+	held_items[/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry] = list("PRICE" = rand(5,10), "dry westleach leaf")
 	held_items[/obj/item/slimepotion/lovepotion] = list("PRICE" = rand(80,100),"NAME" = "love potion")
 	held_items[/obj/item/clothing/head/roguetown/menacing/bandit] = list("PRICE" = rand(5, 25), "NAME" = "ne'er do 'ell mask")
 

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -264,6 +264,7 @@
 	held_items[/obj/item/frost_oil] = list("PRICE" = (50),"NAME" = "frost Oil")
 	held_items[/obj/item/fire_oil] = list("PRICE" = (100),"NAME" = "fire Oil")
 	held_items[/obj/item/acid_oil] = list("PRICE" = (150),"NAME" = "acid oil")
+	held_items[/obj/item/lockpickring] = list("PRICE" = (15), "NAME" = "oil infused lockpicks")
 
 #undef DRUGRADE_MONEYA
 #undef DRUGRADE_MONEYB

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -12,6 +12,8 @@
 	high_threshold_passed = span_warning("Something inside my chest hurts, and the pain isn't subsiding. You notice myself breathing far faster than before.")
 	now_fixed = span_info("My heart begins to beat again.")
 	high_threshold_cleared = span_info("The pain in my chest has died down, and my breathing becomes more relaxed.")
+	sellprice = 100
+	static_price = FALSE
 
 	// Heart attack code is in code/modules/mob/living/carbon/human/life.dm
 	var/beating = 1

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -14,6 +14,8 @@
 	high_threshold_passed = span_warning("I feel some sort of constriction around my chest as my breathing becomes shallow and rapid.")
 	now_fixed = span_warning("My lungs seem to once again be able to hold air.")
 	high_threshold_cleared = span_info("The constriction around my chest loosens as my breathing calms down.")
+	sellprice = 70
+	static_price = FALSE
 
 	//Breath damage
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request


This PR:

- Expands the range of items available from the PURITY
- Moves the PURITY behind the counter. 
- Gives hearts and lungs trade value.
- Adds an uncraftable soporific potion to the game (recipe pending)
- Makes it so enhanced drugs actually provide an enhanced effect.
- Makes drugs a lot better. 
- Removed drug refunds.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- The bath guy needed more tools to play with.
- Cocaine didn't give you energy. 
- Up to this point no one actually sells lethal and nonlethal poisons. 
- The Bathmaster couldn't actually buy dried herbs despite having a plethora of pipes in need of something to fill their tight bowls. 
- The Bathmaster's not really the type of guy to offer refunds.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
