### PR TITLE
Drugs Counteract Narcolepsy

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -400,11 +400,15 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	else
 		// Been conscious for ~10 minutes (whatever is the conscious timer)
 		if(last_unconsciousness + concious_timer < world.time)
-			drugged_up = FALSE
+			//drugged_up = FALSE No idea why you'd lose your high at this point in the process.
 			to_chat(user, span_blue("I'm getting drowsy..."))
 			user.emote("yawn", forced = TRUE)
-			next_sleep = world.time + rand(7 SECONDS, 11 SECONDS)
-			do_sleep = TRUE
+			if(!drugged_up)
+				next_sleep = world.time + rand(7 SECONDS, 11 SECONDS)
+				do_sleep = TRUE
+			else
+				drugged_up = FALSE
+				to_chat(user, span_info("Potent drugs keep me awake. I need more."))
 
 /proc/narcolepsy_drug_up(mob/living/living)
 	var/datum/charflaw/narcoleptic/narco = living.get_flaw(/datum/charflaw/narcoleptic)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
The narcolepsy flaw description states that moondust can keep you awake. In practice, this doesn't actually happen. 
This is because code which fires the narcolepsy check actually disables your high status and only then rolls the actual sleep check. 

This PR fixes it so that you simply skip the sleep check entirely if you're high. This should bring the flaw in line with how it's supposed to be.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Game description-mechanical consistency is good for the game. 
