### PR TITLE
Consensual Conversion Rites for the Sole Purpose of Proselytization

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -161,9 +161,6 @@
 	set category = "Priest"
 	
 	//Don't actually check the convertee's faith so that this can't be used to meta it.
-	if(!istype(get_area(src), /area/rogue/indoors/town/church/chapel))
-		to_chat(src, span_warning("I need to do this in the chapel."))
-		return 
 	var/obj/item/grabbing/I = get_active_held_item()
 	var/mob/living/carbon/human/H
 	if(!istype(I) || !ishuman(I.grabbed))

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -65,6 +65,7 @@
 	H.verbs |= /mob/living/carbon/human/proc/coronate_lord
 	H.verbs |= /mob/living/carbon/human/proc/churchexcommunicate
 	H.verbs |= /mob/living/carbon/human/proc/churchannouncement
+	H.verbs |= /mob/living/carbon/human/proc/psydonconversion
 
 //	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
 
@@ -154,6 +155,29 @@
 			to_chat(src, span_warning("I need to do this from the chapel."))
 			return FALSE
 		priority_announce("[inputty]", title = "The Priest Speaks", sound = 'sound/misc/bell.ogg')
+
+/mob/living/carbon/human/proc/psydonconversion()
+	set name = "Conversion"
+	set category = "Priest"
+	//Don't actually check the convertee's faith so that this can't be used to meta it.
+	if(!istype(get_area(src), /area/rogue/indoors/town/church/chapel))
+		to_chat(src, span_warning("I need to do this in the chapel."))
+		return 
+	var/obj/item/grabbing/I = get_active_held_item()
+	var/mob/living/carbon/human/H
+	if(!istype(I) || !ishuman(I.grabbed))
+		return
+	H = I.grabbed
+	if(H == src)
+		to_chat(src, span_warning("I hold the shepherd's crook."))
+		return
+	if(alert("Do you accept PSYDON as your Lord and Saviour?", "", "Yes", "No") == "Yes")
+		H.set_patron(new /datum/patron/divine/astrata)
+		H.say("I bear witness there is no god but Psydon, and Queen Samantha I is his Annointed Monarch.")
+	else
+		H.emote(pick("gasp","gag","choke"))
+		to_chat(H, span_warning("You feel a sense of unease..."))
+	
 
 /obj/effect/proc_holder/spell/self/convertrole/templar
 	name = "Recruit Templar"

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -170,7 +170,7 @@
 		to_chat(src, span_warning("I am the Shepherd."))
 		return
 
-	/obj/item/rogueweapon/woodstaff/aries = locate() in user.held_items
+	var/obj/item/rogueweapon/woodstaff/aries/required_item = locate() in H.held_items
 	if(!required_item)
 		to_chat(src, span_warning("I must hold my shepherd's crook.."))
 		return

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -159,6 +159,7 @@
 /mob/living/carbon/human/proc/psydonconversion()
 	set name = "Conversion"
 	set category = "Priest"
+	
 	//Don't actually check the convertee's faith so that this can't be used to meta it.
 	if(!istype(get_area(src), /area/rogue/indoors/town/church/chapel))
 		to_chat(src, span_warning("I need to do this in the chapel."))
@@ -169,11 +170,18 @@
 		return
 	H = I.grabbed
 	if(H == src)
-		to_chat(src, span_warning("I hold the shepherd's crook."))
+		to_chat(src, span_warning("I am the Shepherd."))
 		return
-	if(alert("Do you accept PSYDON as your Lord and Saviour?", "", "Yes", "No") == "Yes")
+
+	/obj/item/rogueweapon/woodstaff/aries = locate() in user.held_items
+	if(!required_item)
+		to_chat(src, span_warning("I must hold my shepherd's crook.."))
+		return
+		
+	if(alert(H, "Do you accept PSYDON as your Lord and Saviour?", "PSYDON", "Yes", "No") == "Yes")
 		H.set_patron(new /datum/patron/divine/astrata)
 		H.say("I bear witness there is no god but Psydon, and Queen Samantha I is his Annointed Monarch.")
+		to_chat(H, span_notice("You submit before PSYDON"))
 	else
 		H.emote(pick("gasp","gag","choke"))
 		to_chat(H, span_warning("You feel a sense of unease..."))

--- a/modular_penumbra/zizo.dm
+++ b/modular_penumbra/zizo.dm
@@ -303,17 +303,17 @@
 	return TRUE
 
 /datum/patron/inhumen/zizo/verb/zizoconvert()
-		set name = "Conversion"
-		set category = "CULTIST"
-		set desc = "Lend a fool a spark of Zizo's knowledge."
+	set name = "Conversion"
+	set category = "CULTIST"
+	set desc = "Lend a fool a spark of Zizo's knowledge."
 
-		var/mob/living/carbon/human/user = usr
-		if(!istype(user))
-			return
+	var/mob/living/carbon/human/user = usr
+	if(!istype(user))
+		return
 
 	var/list/valid_targets = list()
 	for(var/mob/living/carbon/human/H in oview(1, user))
-		if(H != user && H.health > 0 && HAS_TRAIT)
+		if(H != user && H.health > 0 && !HAS_TRAIT(H, TRAIT_CABAL))
 			valid_targets[H.name] = H
 
 	if(!length(valid_targets))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This allows the Priest to convert, or rebaptize the faithless (and faithful. (This is to prevent metafreeking.))
They need to grab the target in question and hold their staff in their hand in order to do this. 
The target then decides whether or not to accept Psydon or not. 
The Zizoid leader's also been given a conversion verb of his own to enjoy and use.
But of course the unlucky victim's got to consent to it in any case.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Each side needed a way to consensually convert others to their side of things. 
Though of course priests're meant to only use this on 'faithless' pagans, not apostates!
