### PR TITLE
Secular Mages can Now Cast Blindness

### DIFF
--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -2,7 +2,6 @@
 /obj/effect/proc_holder/spell/invoked/blindness
     name = "Blindness"
     overlay_state = "blindness"
-    req_items = list(/obj/item/clothing/neck/roguetown/psicross)
     releasedrain = 30
     chargedrain = 0
     chargetime = 0
@@ -11,7 +10,7 @@
     warnie = "sydwarning"
     movement_interrupt = FALSE
     sound = 'sound/magic/churn.ogg'
-    invocation = "Psydon blinds thee of thy sins!"
+    invocation = "Turn a blind eye!"
     invocation_type = "shout" //can be none, whisper, emote and shout
     associated_skill = /datum/skill/magic/holy
     antimagic_allowed = TRUE

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -12,7 +12,7 @@
     sound = 'sound/magic/churn.ogg'
     invocation = "Turn a blind eye!"
     invocation_type = "shout" //can be none, whisper, emote and shout
-    associated_skill = /datum/skill/magic/holy
+    associated_skill = /datum/skill/magic/arcane
     antimagic_allowed = TRUE
     charge_max = 15 SECONDS
     devotion_cost = 15


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Blindness is a spell which shows up in the point buy menu for mages. However, those who buy this spell quickly find that they can't actually cast it. This is because a psycross is a required object to cast this, but this makes little sense as a requirement for an arcane spell learnt through the same arcane processes other spells are learnt.

You'll never find a priest with this spell ingame.  

Also the castfail message never specifies that you need to wear a psycross.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Mages can now blind people without metagaming the fact they need a cross. 
It also makes more sense that a spell only arcane magickers can learn would be an arcane spell that uses the arcane magic skill. 
