### PR TITLE
Werewolf Tweaks

### DIFF
--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -516,3 +516,16 @@
 	candodge = TRUE
 	canparry = TRUE
 	item_d_type = "stab"
+
+/datum/intent/unarmed/wwolf
+	name = "claw"
+	icon_state = "inchop"
+	attack_verb = list("claws", "mauls", "eviscerates")
+	animname = "cut"
+	blade_class = BCLASS_CHOP
+	hitsound = "genslash"
+	penfactor = 30
+	candodge = TRUE
+	canparry = TRUE
+	miss_text = "slashes the air!"
+	miss_sound = "bluntwooshlarge"

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
@@ -133,51 +133,6 @@
 	max_integrity = INFINITY //Its integrity carries over each transformation, so this should be infinite since their skin keeps 'regenerating'
 	item_flags = DROPDEL
 
-/datum/intent/simple/werewolf
-	name = "claw"
-	icon_state = "inchop"
-	blade_class = BCLASS_CHOP
-	attack_verb = list("claws", "mauls", "eviscerates")
-	animname = "chop"
-	hitsound = "genslash"
-	penfactor = 50
-	candodge = TRUE
-	canparry = TRUE
-	miss_text = "slashes the air!"
-	miss_sound = "bluntwooshlarge"
-	item_d_type = "slash"
-
-/obj/item/rogueweapon/werewolf_claw
-	name = "Verevolf Claw"
-	desc = ""
-	item_state = null
-	lefthand_file = null
-	righthand_file = null
-	icon = 'icons/roguetown/weapons/32.dmi'
-	max_blade_int = 900
-	max_integrity = 900
-	force = 25
-	block_chance = 0
-	wdefense = 2
-	armor_penetration = 15
-	associated_skill = /datum/skill/combat/unarmed
-	wlength = WLENGTH_NORMAL
-	w_class = WEIGHT_CLASS_BULKY
-	can_parry = TRUE
-	sharpness = IS_SHARP
-	parrysound = "bladedmedium"
-	swingsound = BLADEWOOSH_MED
-	possible_item_intents = list(/datum/intent/simple/werewolf)
-	parrysound = list('sound/combat/parry/parrygen.ogg')
-	embedding = list("embedded_pain_multiplier" = 0, "embed_chance" = 0, "embedded_fall_chance" = 0)
-	item_flags = DROPDEL
-
-/obj/item/rogueweapon/werewolf_claw/right
-	icon_state = "claw_r"
-
-/obj/item/rogueweapon/werewolf_claw/left
-	icon_state = "claw_l"
-
 /obj/item/rogueweapon/werewolf_claw/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, TRAIT_GENERIC)

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
@@ -130,7 +130,7 @@
 	blocksound = SOFTHIT
 	blade_dulling = DULLING_BASHCHOP
 	sewrepair = FALSE
-	max_integrity = 550
+	max_integrity = INFINITY //Its integrity carries over each transformation, so this should be infinite since their skin keeps 'regenerating'
 	item_flags = DROPDEL
 
 /datum/intent/simple/werewolf

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_spells.dm
@@ -33,34 +33,4 @@
 
 	user.log_message("howls: [message] (WEREWOLF)")
 
-/obj/effect/proc_holder/spell/self/claws
-	name = "Lupine Claws"
-	desc = "!"
-	overlay_state = "claws"
-	antimagic_allowed = TRUE
-	charge_max = 20 //2 seconds
-	ignore_cockblock = TRUE
-	var/extended = FALSE
 
-/obj/effect/proc_holder/spell/self/claws/cast(mob/user = usr)
-	..()
-	var/obj/item/rogueweapon/werewolf_claw/left/l
-	var/obj/item/rogueweapon/werewolf_claw/right/r
-
-	l = user.get_active_held_item()
-	r = user.get_inactive_held_item()
-	if(extended)
-		if(istype(user.get_active_held_item(), /obj/item/rogueweapon/werewolf_claw))
-			user.dropItemToGround(l, TRUE)
-			user.dropItemToGround(r, TRUE)
-			qdel(l)
-			qdel(r)
-			//user.visible_message("Your claws retract.", "You feel your claws retracting.", "You hear a sound of claws retracting.")
-			extended = FALSE
-	else
-		l = new(user,1)
-		r = new(user,2)
-		user.put_in_hands(l, TRUE, FALSE, TRUE)
-		user.put_in_hands(r, TRUE, FALSE, TRUE)
-		//user.visible_message("Your claws extend.", "You feel your claws extending.", "You hear a sound of claws extending.")
-		extended = TRUE

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -108,7 +108,7 @@
 	W.mind.skill_experience = list()
 	W.grant_language(/datum/language/beast)
 
-	W.base_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB)
+	W.base_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, /datum/intent/unarmed/wwolf)
 	W.update_a_intents()
 
 	to_chat(W, span_userdanger("I transform into a horrible beast!"))

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -123,7 +123,6 @@
 	W.change_stat("endurance", 5)
 
 	W.AddSpell(new /obj/effect/proc_holder/spell/self/howl)
-	W.AddSpell(new /obj/effect/proc_holder/spell/self/claws)
 
 	ADD_TRAIT(src, TRAIT_NOSLEEP, TRAIT_GENERIC)
 
@@ -179,7 +178,6 @@
 	W.mind.skill_experience = WA.stored_experience.Copy()
 
 	W.RemoveSpell(new /obj/effect/proc_holder/spell/self/howl)
-	W.RemoveSpell(new /obj/effect/proc_holder/spell/self/claws)
 
 	W.regenerate_icons()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
For some reason, someone thought it'd be a good idea to add actual werewolf 'claw' items that they have to extend in order to slash at things. This PR 'corrects' that by making it so they just get a chop intent instead which gives them an 'unarmed' attack which deals the same amount of damage with the very same flavour text.

I briefly considered making WW armour last longer, but I'm not sure if there's a boolean or something that'd make something indestructible without much overhead.
## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Werewolves having to extend their claws is kind of goofy and was an unnecessary layer of jank added to the game.
This lets werewolves maim and kill without as much of a hassle. 
